### PR TITLE
Documentation: add info on WAR and static build

### DIFF
--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -37,8 +37,7 @@ Static Build
 Kiln includes a task that allows to create a static version of the website. To execute it:
 
 * Run the build script as described above to start the web application.
-* Set the ``default`` attribute of the ``project`` in ``local.build.xml`` to ``static`` (instead of ``runserver``).
-* Re-run the build script.
+* Re-run the build script supplying ``static`` as argument.
 
 
 WAR Build (Web Application Archive)
@@ -46,6 +45,4 @@ WAR Build (Web Application Archive)
 
 Kiln includes a task that allows to create a Web Application Archive (for use with `Apache Tomcat`_, e.g.). To execute it:
 
-* Run the build script as described above to start the web application.
-* Set the ``default`` attribute of the ``project`` in ``local.build.xml`` to ``war`` (instead of ``runserver``).
-* Re-run the build script.
+* Run the build script supplying ``war`` as argument.

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -29,3 +29,23 @@ such a file is provided at ``webapps/solr/conf/solr.xml``.
 
 .. _Jetty: http://www.eclipse.org/jetty/
 .. _Apache Tomcat: http://tomcat.apache.org/
+
+
+Static Build
+----------
+
+Kiln includes a task that allows to create a static version of the website. To execute it:
+
+* Run the build script as described above to start the web application.
+* Set the ``default`` attribute of the ``project`` in ``local.build.xml`` to ``static`` (instead of ``runserver``).
+* Re-run the build script.
+
+
+WAR Build (Web Application Archive)
+----------
+
+Kiln includes a task that allows to create a Web Application Archive (for use with `Apache Tomcat`_, e.g.). To execute it:
+
+* Run the build script as described above to start the web application.
+* Set the ``default`` attribute of the ``project`` in ``local.build.xml`` to ``war`` (instead of ``runserver``).
+* Re-run the build script.


### PR DESCRIPTION
The documentation mentions the possibilities to build to `WAR` and `static` (at [`components.rst`](components.rst)), but more specific information is missing. 
Let me know if there is a better way to do this than what I sketched here.

Btw, great to see the recent activity here!